### PR TITLE
Add add_vertex!, add_vertices!, add_edge! methods 

### DIFF
--- a/src/Networks.jl
+++ b/src/Networks.jl
@@ -25,8 +25,10 @@ Network{G,V}(::Type{G}, ::Type{V}) = Network(G(), V[], Dict{Edge,Void}())
 import Base.==
 
 function add_vertex!{G,V,E}(g::Network{G,V,E}, vertex_info::V)
-    add_vertex!(g.graph)
+    n = add_vertex!(g.graph)
     push!(g.vprop, vertex_info)
+
+    return n
 end
 
 function add_vertices!{G,V,E}(g::Network{G,V,E}, vertex_info::Vector{V})
@@ -39,6 +41,7 @@ end
 function add_edge!{G,V,E}(g::Network{G,V,E}, i, j, edge_info::E)
     e = add_edge!(g.graph, i, j)
     (g.eprop)[e] = edge_info
+    return e
 end
 
 add_edge!{G,V,E}(g::Network{G,V,E}, i, j) = add_edge!(g.graph, i, j)

--- a/src/Networks.jl
+++ b/src/Networks.jl
@@ -1,6 +1,7 @@
 module Networks
 using LightGraphs
-import LightGraphs: Graph, DiGraph, fadj
+import LightGraphs: Graph, DiGraph, fadj,
+        add_vertex!, add_vertices!, add_edge!
 import Base.convert, Base.promote_rule
 
 export AbstractNetwork, Network
@@ -12,11 +13,37 @@ The vertex properites are of type V and the edge properties are of type E.
 """
 type Network{G,V,E} <: AbstractNetwork
   graph::G
-  vprop::AbstractVector{V}
+  vprop::Vector{V}
   eprop::Dict{Edge,E}
 end
 
+Network{G,V,E}(::Type{G}, ::Type{V}, ::Type{E}) = Network(G(), V[], Dict{Edge,E}())
+Network{G,V}(::Type{G}, ::Type{V}) = Network(G(), V[], Dict{Edge,Void}())
+
+
+
 import Base.==
+
+function add_vertex!{G,V,E}(g::Network{G,V,E}, vertex_info::V)
+    add_vertex!(g.graph)
+    push!(g.vprop, vertex_info)
+end
+
+function add_vertices!{G,V,E}(g::Network{G,V,E}, vertex_info::Vector{V})
+    for vertex in vertex_info
+        add_vertex!(g.graph)
+        push!(g.vprop, vertex)
+    end
+end
+
+function add_edge!{G,V,E}(g::Network{G,V,E}, i, j, edge_info::E)
+    e = add_edge!(g.graph, i, j)
+    (g.eprop)[e] = edge_info
+end
+
+add_edge!{G,V,E}(g::Network{G,V,E}, i, j) = add_edge!(g.graph, i, j)
+
+
 
 ==(n::Network, m::Network) = (n.graph == m.graph) && (n.vprop == m.vprop) && (n.eprop == m.eprop)
 
@@ -29,10 +56,10 @@ function convert{T<:SimpleGraph, G,V,E}(::Type{T}, net::Network{G,V,E})
     end
 end
 
-# promotion_rule{T<:SimpleGraph}(::Type{T}, ::Type{Network}) = T 
+# promotion_rule{T<:SimpleGraph}(::Type{T}, ::Type{Network}) = T
 promote_rule{T<:SimpleGraph, V, E}(::Type{Network{T,V,E}}, ::Type{T}) = T
 
-# this is how one could define methods in LightGraphs 
+# this is how one could define methods in LightGraphs
 # to make everything work for types that embed a graph
 fadj(g::Any) = fadj(convert(SimpleGraph, g))
 end

--- a/src/Networks.jl
+++ b/src/Networks.jl
@@ -1,32 +1,36 @@
 module Networks
-using LightGraphs
-import LightGraphs: Graph, DiGraph, fadj,
+
+import LightGraphs: Graph, DiGraph, SimpleGraph, Edge,
+        fadj,
         add_vertex!, add_vertices!, add_edge!
+
 import Base.convert, Base.promote_rule
+import Base.==
 
 export AbstractNetwork, Network
 abstract AbstractNetwork
 
-"""Network{G,V,E}
-Network is the core type for store Graphs with vertex and edge properties.
-The vertex properites are of type V and the edge properties are of type E.
+"""
+    `Network{G,V,E}`
+
+`Network` is the core type for representing graphs with vertex and edge properties.
+`G` is the type of the underlying graph; the vertex properties are of type `V`,
+and the edge properties are of type `E`.
 """
 type Network{G,V,E} <: AbstractNetwork
   graph::G
-  vprop::Vector{V}
-  eprop::Dict{Edge,E}
+  vprops::Vector{V}
+  eprops::Dict{Edge,E}
 end
 
+# convenience constructors for empty `Network`s with given types:
 Network{G,V,E}(::Type{G}, ::Type{V}, ::Type{E}) = Network(G(), V[], Dict{Edge,E}())
 Network{G,V}(::Type{G}, ::Type{V}) = Network(G(), V[], Dict{Edge,Void}())
 
 
-
-import Base.==
-
 function add_vertex!{G,V,E}(g::Network{G,V,E}, vertex_info::V)
     n = add_vertex!(g.graph)
-    push!(g.vprop, vertex_info)
+    push!(g.vprops, vertex_info)
 
     return n
 end
@@ -34,23 +38,25 @@ end
 function add_vertices!{G,V,E}(g::Network{G,V,E}, vertex_info::Vector{V})
     for vertex in vertex_info
         add_vertex!(g.graph)
-        push!(g.vprop, vertex)
+        push!(g.vprops, vertex)
     end
 end
 
 function add_edge!{G,V,E}(g::Network{G,V,E}, i, j, edge_info::E)
     e = add_edge!(g.graph, i, j)
-    (g.eprop)[e] = edge_info
+    (g.eprops)[e] = edge_info
     return e
 end
 
 add_edge!{G,V,E}(g::Network{G,V,E}, i, j) = add_edge!(g.graph, i, j)
 
 
+==(n::Network, m::Network) = (n.graph == m.graph) && (n.vprops == m.vprops) && (n.eprops == m.eprops)
 
-==(n::Network, m::Network) = (n.graph == m.graph) && (n.vprop == m.vprop) && (n.eprop == m.eprop)
+# conversion to underlying Graph:
 
 Graph(net::Network) = net.graph
+
 function convert{T<:SimpleGraph, G,V,E}(::Type{T}, net::Network{G,V,E})
     if typeof(net.graph) <: T
         return net.graph

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
-using Networks
 using LightGraphs
+using Networks
 using Base.Test
 
 # write your own tests here
@@ -13,22 +13,24 @@ function prepgraph(g)
     add_edge!(g, 3,4)
     add_edge!(g, 4,5)
     add_edge!(g, 5,1)
-    net = Network(g, 1:nv(g), Dict{Edge, Float64}())
-    net.eprop[Edge(5,1)] = 2.3
+    net = Network(g, collect(1:nv(g)), Dict{Edge, Float64}())
+    net.eprops[Edge(5, 1)] = 2.3
     return net
 end
+
 net = prepgraph(g)
+
 @test convert(Graph, net) == g
 @test Graph(net) == g
 @test fadj(net) == fadj(g)
-@test_throws ErrorException convert(DiGraph, net) 
+@test_throws ErrorException convert(DiGraph, net)
 
 dnet = prepgraph(dg)
 @test convert(DiGraph, dnet) == dg
 @test fadj(dnet) == fadj(dg)
-@test_throws ErrorException convert(Graph, dnet) 
+@test_throws ErrorException convert(Graph, dnet)
 
-# test that least upper bound type 
+# test that least upper bound type
 # of a network and a graph is the compatible graph type
 @test promote_rule(Network{Graph,Int,Int}, Graph) == Graph
 @test promote_rule(Network{DiGraph,Int,Int}, DiGraph) == DiGraph
@@ -39,3 +41,17 @@ dnet = prepgraph(dg)
 @test promote_rule(Network{Graph,Int,Int}, DiGraph) == Union{}
 @test promote(net, dg) == (net, dg)
 @test promote(dnet, g) == (dnet, g)
+
+
+g = Graph()
+add_vertex!(g)
+add_vertex!(g)
+add_edge!(g, 1, 2)
+
+net = Network(Graph, String)
+add_vertex!(net, "a")
+add_vertex!(net, "b")
+add_edge!(net, 1, 2)
+
+@test net.graph == g
+@test net.vprops == ["a", "b"]


### PR DESCRIPTION
- Change `AbstractVector` -> `Vector` in the type definition.
- Add convenience constructors for `Network` with given types (including allowing `Void` for edges to label only vertices).
- Add `add_vertex!`, `add_vertices!`, `add_edge!` methods.
