### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ os:
   - linux
 #  - osx
 julia:
-  - 0.5
-  - nightly
+  - 0.6
 
 notifications:
   email: false


### PR DESCRIPTION
.travis.yml: drop support for julia v0.5 and latest.